### PR TITLE
fix: remove unused test

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           cache-on-failure: true
 
-      - run: cargo test --workspace --all-features --verbose -- --ignored
+      - run: cargo test --workspace --all-targets --all-features --verbose -- --ignored
 
       - name: Check for uncommitted Cargo.lock changes
         run: |

--- a/veecle-freertos-examples/examples/linux/main.rs
+++ b/veecle-freertos-examples/examples/linux/main.rs
@@ -46,15 +46,3 @@ fn main() {
         println!("Loop forever!");
     }
 }
-
-#[test]
-fn many_boxes() {
-    init_allocator();
-    println!("many_boxes... ");
-    for i in 0..10 {
-        // .. HEAP_SIZE
-        let x = Box::new(i);
-        assert_eq!(*x, i);
-    }
-    println!("[ok]");
-}


### PR DESCRIPTION
The first commit adapts CI to catch the issue, the second one removes the test.

The CI run showing that the test would now be caught: https://github.com/veecle/freertos-integration/actions/runs/17787954780/job/50558909795?pr=17

<!---

Thanks for creating a pull request!

## TODO

 - 🚧 Consider if this PR is release-notes-worthy, and update CHANGELOG.md if so.

 - 🚧 Added/updated relevant documentation in README, crate, module, function and/or other locations.

 - 🚧 New tests added and/or existing tests adapted.

 - 🚧 PR is limited to a single logical change.
   For example, if you add a feature, don't include fixes you made along the way

 - 🚧 At least the first commit has a clear title and a descriptive message containing reasoning for the change.
   This will be included in the final commit message after squashing and merging.

 - 🚧 PR title starts with an appropriate prefix as specified by [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification):

       chore: [your title]
       docs: [your title]
       feat: [your title]
       fix: [your title]
       refactor: [your title]
       test: [your title]

 - 🚧 PR description explains what it intends to achieve.

 - 🚧 Relevant issues are linked.

 - 🚧 For more complex PRs, PR description explains _how_ this was achieved.
   Did you consider different approaches, were there any trade-offs you made?
   More information about why you implemented your solution the way you did helps reviewers.

(Feel free to delete this comment once you've checked your PR against the requirements, for a draft PR it can be useful to uncomment and leave not-yet-completed steps in a TODO section so reviewers know the current state).

-->
