### PR TITLE
ci: validate commits in merge queue

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -122,7 +122,7 @@ jobs:
 
   commits:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'merge_group' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -135,7 +135,9 @@ jobs:
           version: 0.6.2
 
       - name: Check conventional commits
-        run: convco check
+        # We require squash-merge, which means only one commit will be added per PR.
+        # We cannot check the complete history as it contains a commit that doesn't follow conventional commits.
+        run: convco check -n 1
 
   yamllint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Moves the commit validation from PR to merge queue. This allows us to verify the commit that lands in `main` will actually have a correct commit message.

`GITHUB_BASE_REF` isn't available in merge queues/groups, so we just check the latest commit. Since we require squash-merge, this will be the only commit added per PR.