### PR TITLE
chore: increase max line length for yaml files to 200

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -14,7 +14,7 @@ rules:
   comments-indentation:
     level: error
   line-length:
-    max: 120
+    max: 200
   new-line-at-end-of-file: enable
   new-lines:
     type: unix


### PR DESCRIPTION
This matches what we use in `veecle-os`: https://github.com/veecle/veecle-os/blob/9b6f1c18538c320e7deb0e7a1992d7371f2cf6a1/.yamllint#L20C10-L20C13