### PR TITLE
refactor: replace `doc_auto_cfg` with `doc_cfg`

### DIFF
--- a/veecle-freertos-integration/src/lib.rs
+++ b/veecle-freertos-integration/src/lib.rs
@@ -11,7 +11,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 extern crate alloc;
 

--- a/veecle-freertos-sys/src/lib.rs
+++ b/veecle-freertos-sys/src/lib.rs
@@ -1,6 +1,6 @@
 //! FreeRTOS low-level Rust bindings.
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(test)]
 extern crate std;


### PR DESCRIPTION
`doc_auto_cfg` has been merged into `doc_cfg` in https://github.com/rust-lang/rust/pull/138907.